### PR TITLE
Ensure correct python environment is used

### DIFF
--- a/s3wipe
+++ b/s3wipe
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, Queue, logging, random, sys
 import multiprocessing, signal, re


### PR DESCRIPTION
Saw an issue on OSX with two versions of python (standard OSX python and brew installed python), where the standard python didn't have the boto library installed but the brew installed python did. 

Using /usr/bin/env ensured the correct one was used avoiding the "wrong version of boto" error due to missing boto library from standard/OSX python.
