### PR TITLE
add --listthreads/--deletethreads flags

### DIFF
--- a/s3wipe
+++ b/s3wipe
@@ -54,6 +54,12 @@ def getArgs():
     parser.add_argument("--maxthreads",
         help="Max number of threads (default 100)",
         type=int, default=100)
+    parser.add_argument("--deletethreads",
+        help="Number of delete threads (optional)",
+        type=int)
+    parser.add_argument("--listthreads",
+        help="Number of list threads (optional)",
+        type=int)
     parser.add_argument("--delbucket", 
         help="If S3 path is a bucket path, delete the bucket also",
         action='store_true')
@@ -207,7 +213,13 @@ def main():
         if (listThreads + deleteThreads) > args.maxthreads:
             listThreads = args.maxthreads / 3
             deleteThreads = args.maxthreads - listThreads
-        
+
+        # cli flags override calculated thread counts
+        if args.deletethreads:
+            deleteThreads = args.deletethreads
+        if args.listthreads:
+            listThreads = args.listthreads
+
         logger.info("Starting %s delete threads..." % deleteThreads)
         deleterPool = ThreadPool(processes=deleteThreads, 
             initializer=deleter, initargs=(args, rmQueue, deleteThreads))


### PR DESCRIPTION
These flags override the thread counts computed from the value of
--maxthreads.  The ability to directly control these values may be
useful when trying to tune the batchsize to deletethreads ratio.