### PR TITLE
Add support for AWS temp credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ optional arguments:
   --path PATH            S3 path to delete (e.g. s3://bucket/path)
   --id ID                Your AWS access key ID
   --key KEY              Your AWS secret access key
+  --token TOKEN          Your AWS secret token
   --dryrun               Don't delete. Print what we would have deleted
   --quiet                Suprress all non-error output
   --batchsize BATCHSIZE  # of keys to batch delete (default 100)
@@ -87,6 +88,9 @@ optional arguments:
 ```
 
 ## Changelog
+_v0.3_
+    You can now specify an AWS security token, which is required when using
+    temporary credentials.  (eg, AssumeRole / AssumeRoleWithSAML)
 
 _v0.2_
 

--- a/s3wipe
+++ b/s3wipe
@@ -40,6 +40,8 @@ def getArgs():
         help="Your AWS access key ID", required=False)
     parser.add_argument("--key", 
         help="Your AWS secret access key", required=False)
+    parser.add_argument("--token",
+        help="Your AWS access token", required=False)
     parser.add_argument("--dryrun", 
         help="Don't delete.  Print what we would have deleted", 
         action='store_true')
@@ -95,7 +97,8 @@ def deleter(args, rmQueue, numThreads):
     # Set up per-thread boto objects
     myconn = boto.s3.connection.S3Connection(                                  
         aws_access_key_id=args.id,
-        aws_secret_access_key=args.key)
+        aws_secret_access_key=args.key,
+        security_token=args.token)
     bucket, path = args.path
     mybucket = myconn.get_bucket(bucket)
 
@@ -145,7 +148,8 @@ def lister(subDir):
     # Set up our per-thread boto connection
     myconn = boto.s3.connection.S3Connection(                                  
         aws_access_key_id=args.id,
-        aws_secret_access_key=args.key)
+        aws_secret_access_key=args.key,
+	    security_token=args.token)
     bucket, path = args.path
     mybucket = myconn.get_bucket(bucket)
 
@@ -183,7 +187,8 @@ def main():
     # watcher threads on a per-subdir basis
     conn = boto.s3.connection.S3Connection(                                  
         aws_access_key_id=args.id,
-        aws_secret_access_key=args.key)
+        aws_secret_access_key=args.key,
+        security_token=args.token)
 
     try:
         mybucket = conn.get_bucket(bucket)


### PR DESCRIPTION
When using temporary credentials, AWS services also need the security token.  This PR adds support for this.